### PR TITLE
Fix strange behaviour of mass start stop

### DIFF
--- a/streams.php
+++ b/streams.php
@@ -30,6 +30,9 @@ if(isset($_POST['mass_delete'])) {
 
         foreach($_POST['mselect'] as $streamids) {
             $stream = Stream::find($streamids);
+            if($stream->running == 1)
+                stop_stream($streamids);
+            }
             $stream->delete();
         }
     }
@@ -43,7 +46,10 @@ if(isset($_POST['mass_start'])) {
     if (isset($_POST['mselect'])) {
 
         foreach($_POST['mselect'] as $streamids) {
-            start_stream($streamids);
+            $stream = Stream::find($streamids);
+            if($stream->running == 0)
+                start_stream($streamids);
+            }
         }
     }
 
@@ -56,7 +62,10 @@ if(isset($_POST['mass_stop'])) {
     if (isset($_POST['mselect'])) {
 
         foreach($_POST['mselect'] as $streamids) {
-            stop_stream($streamids);
+            $stream = Stream::find($streamids);
+            if($stream->running == 1)
+                stop_stream($streamids);
+            }
         }
     }
 

--- a/streams.php
+++ b/streams.php
@@ -18,6 +18,9 @@ if (isset($_GET['start'])){
 
 if(isset($_GET['delete'])) {
     $stream = Stream::find($_GET['delete']);
+    if($stream->running == 1)
+        stop_stream($_GET['delete']);
+    }
     $stream->delete();
 
     $message['type'] = "success";

--- a/streams.php
+++ b/streams.php
@@ -18,7 +18,7 @@ if (isset($_GET['start'])){
 
 if(isset($_GET['delete'])) {
     $stream = Stream::find($_GET['delete']);
-    if($stream->running == 1)
+    if($stream->running == 1) {
         stop_stream($_GET['delete']);
     }
     $stream->delete();
@@ -33,7 +33,7 @@ if(isset($_POST['mass_delete'])) {
 
         foreach($_POST['mselect'] as $streamids) {
             $stream = Stream::find($streamids);
-            if($stream->running == 1)
+            if($stream->running == 1) {
                 stop_stream($streamids);
             }
             $stream->delete();
@@ -50,7 +50,7 @@ if(isset($_POST['mass_start'])) {
 
         foreach($_POST['mselect'] as $streamids) {
             $stream = Stream::find($streamids);
-            if($stream->running == 0)
+            if($stream->running == 0) {
                 start_stream($streamids);
             }
         }
@@ -66,7 +66,7 @@ if(isset($_POST['mass_stop'])) {
 
         foreach($_POST['mselect'] as $streamids) {
             $stream = Stream::find($streamids);
-            if($stream->running == 1)
+            if($stream->running == 1) {
                 stop_stream($streamids);
             }
         }

--- a/views/manage_stream.blade.php
+++ b/views/manage_stream.blade.php
@@ -18,7 +18,7 @@
                                 </div>
                             @endif
                             <br>
-                            <form id="demo-form2" data-parsley-validate="" class="form-horizontal form-label-left" novalidate="" role="form" action="" method="post">
+                            <form id="demo-form2" data-parsley-validate="" class="form-horizontal form-label-left" novalidate="" role="form" action="streams.php" method="post">
 
                                 <div class="form-group">
                                     <label class="control-label col-md-3 col-sm-3 col-xs-12" for="first-name">Name <span class="required">*</span>

--- a/views/manage_stream.blade.php
+++ b/views/manage_stream.blade.php
@@ -18,7 +18,7 @@
                                 </div>
                             @endif
                             <br>
-                            <form id="demo-form2" data-parsley-validate="" class="form-horizontal form-label-left" novalidate="" role="form" action="streams.php" method="post">
+                            <form id="demo-form2" data-parsley-validate="" class="form-horizontal form-label-left" novalidate="" role="form" action="" method="post">
 
                                 <div class="form-group">
                                     <label class="control-label col-md-3 col-sm-3 col-xs-12" for="first-name">Name <span class="required">*</span>

--- a/views/streams.blade.php
+++ b/views/streams.blade.php
@@ -16,7 +16,7 @@
                         </ul>
                         <div class="clearfix"></div>
                     </div>
-                    <form action=""method="post">
+                    <form action="streams.php" method="post">
                         <input type="submit" name="mass_start" value="Mass start" class="btn btn-small btn-success" onclick="return confirm('Are you sure?')">
                         <input type="submit" name="mass_stop" value="Mass stop" class="btn btn-small btn-danger" onclick="return confirm('Are you sure?')">
                         <input type="submit" name="mass_delete" value="Mass delete" class="btn btn-small btn-danger" onclick="return confirm('Are you sure?')">


### PR DESCRIPTION
You could start running streams multiple times if you select them for mass start.
Parameter ?start=x will now be removed so reloading the page doesn't start the stream a second time.
Also stops stream before deletion.
