### PR TITLE
Update stream.php

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -100,7 +100,7 @@ if (isset($_GET['username']) && isset($_GET['password']) && isset($_GET['stream'
                                 $nextnext = sprintf($stream->id . "_%d.ts", $segment + 2);
                                 if (!file_exists($folder . $next)) {
                                     sleep(1);
-                                    $try++;
+                                    //$try++;
                                     continue;
                                 }
                                 $try = 0;
@@ -109,7 +109,7 @@ if (isset($_GET['username']) && isset($_GET['password']) && isset($_GET['stream'
                                     $line = stream_get_line($fopen, 4096);
                                     if (empty($line)) {
                                         sleep(1);
-                                        ++$try;
+                                        //++$try;
                                         continue;
                                     }
                                     echo $line;


### PR DESCRIPTION
Same times not on all streams the client stream crash ( if the stream fils is 19 or change 19 to 20 this happen, as example parallel on stream get black pic and image again this make the client stream crash  ). This affect the $active_cons also and make the clients no respect the user limit. The comment on //++$try fix that behavior and client never crash, but if your channel go down or stopped by you, have to clear the activity log to get the client on line again. I have no idea how ti fix that is my first tach with php staff and if any one helps is very good :) thanks